### PR TITLE
kombu >= 2.5.12

### DIFF
--- a/requirements.pip
+++ b/requirements.pip
@@ -1,4 +1,4 @@
 requests>=0.14
-kombu==2.3.2
+kombu>=2.5.12
 nose==1.3.0
 statsd>=2.1.2

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ REQUIREMENTS = [
 if __name__ == "__main__":
     setuptools.setup(
         name="queue_util",
-        version="0.0.9",
+        version="0.0.10",
         author="Sujay Mansingh",
         author_email="sujay.mansingh@gmail.com",
         packages=setuptools.find_packages(),

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import setuptools
 # How do we keep this in sync with requirements.pip?
 #
 REQUIREMENTS = [
-    "kombu==2.3.2",
+    "kombu>=2.5.12",
     "nose==1.3.0",
     "requests>=0.14",
     "statsd>=2.1.2",


### PR DESCRIPTION
This updates Kombu to above 2.5.12, which stops conflicts between user_activity_client & Celery. Checked the changelog and nothing appears to have changed which would affect queue_util.