### PR TITLE
bump kombu to a version that supports python 3.4

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.md merge=union

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# Changelog
+### Unreleased - leave this line in when you do a release, and leave 1 blank line underneath what you release
+
 ## v1.0.1
 - Fix setup.py for Python 3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ### Unreleased - leave this line in when you do a release, and leave 1 blank line underneath what you release
+- [breaking] Update kombu to a version that supports Python 3.4
 
 ## v1.0.1
 - Fix setup.py for Python 3

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ import sys
 
 
 REQUIREMENTS = [
-    "kombu>=2.5,<2.6",
+    "kombu>=3.0.12,<4",
     "requests>=2,<3",
     "six>=1.10.0,<2",
     "statsd>=2.1,<2.2",


### PR DESCRIPTION
@EDITD/hackers, this adds support for python 3.4 by bumping the version of kombu. This version of kombu requires that we enable the unsafe serializers by default. That's fine, but it will be a major version bump!