### PR TITLE
add unicode-msgpack as a serializer for all queue_util uses

### DIFF
--- a/queue_util/__init__.py
+++ b/queue_util/__init__.py
@@ -1,4 +1,4 @@
-from queue_util.consumer import Consumer
-from queue_util.producer import Producer
-from queue_util.producer import get_num_messages
+from .consumer import Consumer
+from .producer import Producer
+from .producer import get_num_messages
 from . import serializers

--- a/queue_util/__init__.py
+++ b/queue_util/__init__.py
@@ -1,26 +1,4 @@
 from queue_util.consumer import Consumer
 from queue_util.producer import Producer
 from queue_util.producer import get_num_messages
-
-# kombu v4 will come out with the following commit in:
-# https://github.com/celery/kombu/commit/010aae8ccf16ad2fa5a9c3d6f3b84b21e1c1677a
-# which does the same thing, but this also allows us to not have to enable
-# insecure serializers
-import msgpack
-from kombu.serialization import register
-
-
-def pack(s):
-    return msgpack.packb(s, use_bin_type=True)
-
-
-def unpack(s):
-    return msgpack.unpackb(s, encoding='utf-8')
-
-register(
-    'unicode-msgpack',
-    pack,
-    unpack,
-    content_type='application/x-unicode-msgpack',
-    content_encoding='binary'
-)
+from . import serializers

--- a/queue_util/__init__.py
+++ b/queue_util/__init__.py
@@ -1,4 +1,4 @@
-from .consumer import Consumer
-from .producer import Producer
-from .producer import get_num_messages
-from . import serializers
+from .consumer import Consumer  # noqa
+from .producer import Producer  # noqa
+from .producer import get_num_messages  # noqa
+from . import serializers  # noqa

--- a/queue_util/__init__.py
+++ b/queue_util/__init__.py
@@ -1,3 +1,26 @@
 from queue_util.consumer import Consumer
 from queue_util.producer import Producer
 from queue_util.producer import get_num_messages
+
+# kombu v4 will come out with the following commit in:
+# https://github.com/celery/kombu/commit/010aae8ccf16ad2fa5a9c3d6f3b84b21e1c1677a
+# which does the same thing, but this also allows us to not have to enable
+# insecure serializers
+import msgpack
+from kombu.serialization import register
+
+
+def pack(s):
+    return msgpack.packb(s, use_bin_type=True)
+
+
+def unpack(s):
+    return msgpack.unpackb(s, encoding='utf-8')
+
+register(
+    'unicode-msgpack',
+    pack,
+    unpack,
+    content_type='application/x-unicode-msgpack',
+    content_encoding='binary'
+)

--- a/queue_util/serializers.py
+++ b/queue_util/serializers.py
@@ -1,0 +1,22 @@
+# kombu v4 will come out with the following commit in:
+# https://github.com/celery/kombu/commit/010aae8ccf16ad2fa5a9c3d6f3b84b21e1c1677a
+# which does the same thing, but this also allows us to not have to enable
+# insecure serializers
+import msgpack
+from kombu.serialization import register
+
+
+def pack(s):
+    return msgpack.packb(s, use_bin_type=True)
+
+
+def unpack(s):
+    return msgpack.unpackb(s, encoding='utf-8')
+
+register(
+    'unicode-msgpack',
+    pack,
+    unpack,
+    content_type='application/x-unicode-msgpack',
+    content_encoding='binary'
+)

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@ import sys
 
 REQUIREMENTS = [
     "kombu>=3.0.12,<4",
+    "msgpack-python>0.4.7,<0.5",
     "requests>=2,<3",
     "six>=1.10.0,<2",
     "statsd>=2.1,<2.2",


### PR DESCRIPTION
@EDITD/hackers this is the final piece in being able to send msgpack messages between things in the pipe. It means we will specify `'unicode-msgpack'` when saying what the serializer will be for a message.