### PR TITLE
ignore all unicode errors on read and write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ### Unreleased - leave this line in when you do a release, and leave 1 blank line underneath what you release
+- Ignore unicode_errors on read and write with `unicode-msgpack`
 
 ## v2.1.1
 - Fix `msgpack-python` dependency

--- a/queue_util/serializers.py
+++ b/queue_util/serializers.py
@@ -7,11 +7,11 @@ from kombu.serialization import register
 
 
 def pack(s):
-    return msgpack.packb(s, use_bin_type=True)
+    return msgpack.packb(s, use_bin_type=True, unicode_errors='ignore')
 
 
 def unpack(s):
-    return msgpack.unpackb(s, encoding='utf-8')
+    return msgpack.unpackb(s, encoding='utf-8', unicode_errors='ignore')
 
 register(
     'unicode-msgpack',


### PR DESCRIPTION
@EDITD/hackers, we've had to add this in a lot of places to deal with some of the dodgy data that we've got hanging about. Because `skuscraper` will out outputting `unicode-msgpack` shortly, and it's the source of all issues we should just remove the errors at that point, when it `pack`s onto the queue.